### PR TITLE
Disable validate table

### DIFF
--- a/src/Writer/PgsqlWriteAdapter.php
+++ b/src/Writer/PgsqlWriteAdapter.php
@@ -165,4 +165,8 @@ class PgsqlWriteAdapter extends PdoWriteAdapter
 
         $this->logger->info(sprintf('Data moved into table "%s".', $exportConfig->getDbName()));
     }
+
+    public function validateTable(string $tableName, array $items): void
+    {
+    }
 }


### PR DESCRIPTION
po releasu se stávalo že neprošlo validací, protože v DB byly jiný typy než v konfiguraci... v původní verzi byla validace taky vypnutá - https://github.com/keboola/db-writer-pgsql/blob/v1/src/Writer/Pgsql.php#L91